### PR TITLE
Demonstrate Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,16 +3,8 @@
 module.exports = {
   name: "ember-c3",
 
-  options: {
-    autoImport: {
-      publicAssetURL: {
-        'c3': 'node_modules/c3/c3.js'
-      }
-    }
-  },
-
   included: function(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
     app.import("node_modules/c3/c3.css");
   }


### PR DESCRIPTION
Fix for https://github.com/ef4/ember-auto-import/issues/145.

The bug was the way `_super.included` was called. ember-cli breaks if you don't bind `this` here. Yeah, I know, that seems bad and I don't know why it does that.

I also removed the `publicAssetURL` option to autoImport, which wasn't doing anything and doesn't really belong in an addon anyway. It's purpose is to say where assets are hosted in production (if you happen to move your Javascript files to weird URLs).